### PR TITLE
fix(pages): add docs/index.html so root URL serves architecture diagram

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Architecture — redirecting</title>
+<meta http-equiv="refresh" content="0; url=architecture.html">
+<link rel="canonical" href="architecture.html">
+</head>
+<body>
+<p>Redirecting to <a href="architecture.html">architecture diagram</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Pages source is `main@/docs`, build status `built`, but root URL `citadel-cloud-management.github.io/terraform-gcp-vpc-network/` returns 404 because there is no `docs/index.html` — only `docs/architecture.html`.
- Adds a tiny `docs/index.html` that meta-refreshes to `architecture.html`, so the canonical Pages URL resolves while existing direct links to `architecture.html` keep working unchanged.

## Test plan
- [ ] After merge + Pages rebuild, hit `/terraform-gcp-vpc-network/` and confirm it lands on the architecture diagram
- [ ] Confirm `/terraform-gcp-vpc-network/architecture.html` still works (unchanged)